### PR TITLE
feat: option to disable lazy loading on images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ By default, the tool looks for a configuration file named `scraper.config.json`.
 - `--directories <dirs...>`: Specific directories to include in the scraping process (optional)
 - `--customStyles <styles...>`: Add custom styles as a string to override defaults (optional)
 - `--output <path>`: Output path for the generated PDF (default: `./output/docs.pdf`)
+- `--forceImages`: Disable lazy loading for images (default: `false`)
 
 ## Examples
 
@@ -76,6 +77,18 @@ CLI equivalent: `npx docusaurus-to-pdf --baseUrl https://hasura.io --entryPoint 
   "baseUrl": "https://hasura.io",
   "entryPoint": "https://hasura.io/docs/3.0",
   "customStyles": "table { max-width: 3500px !important }"
+}
+```
+
+### Example 5: Scraping without lazy loading on images
+
+CLI equivalent: `npx docusaurus-to-pdf --baseUrl https://docusaurus.io --entryPoint https://docusaurus.io/docs --forceImages`
+
+```json
+{
+  "baseUrl": "https://docusaurus.io",
+  "entryPoint": "https://docusaurus.io/docs",
+  "forceImages": true
 }
 ```
 

--- a/__tests__/generator/rendering.test.ts
+++ b/__tests__/generator/rendering.test.ts
@@ -1,0 +1,44 @@
+import puppeteer, { Browser } from "puppeteer";
+import {forceImagesLoading} from "../../src/generator/utils";
+
+describe("check images rendering", () => {
+  
+  let browser: Browser;
+
+  it("should be able to display every image before passing the page to pdf generator", async () => {
+    const docsWithLazyImages = 'https://quickwit.io/docs/get-started/tutorials/tutorial-jaeger';
+    browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    await page.goto(docsWithLazyImages, { waitUntil: "domcontentloaded" });
+
+    // Check if page has unloaded images
+    const hasLazyImages = await page.evaluate(() => {
+      const images = [...document.querySelectorAll('img')];
+      return images.some((img) => !img.complete || img.naturalWidth === 0);
+    });
+
+    expect(hasLazyImages).toBe(true);
+
+    // Get html page
+    const html = await page.content();
+
+    // Remove loading attribute from img elements
+    const pageWithoutLazyImages = forceImagesLoading(html)
+
+    // Refresh page with new html
+    await page.setContent(pageWithoutLazyImages)
+
+    // Check if every image is loaded
+    const checkLoadedImages = await page.evaluate(() => {
+      const images = [...document.querySelectorAll('img')];
+      return images.every((img) => img.complete && img.naturalWidth > 0);
+    });
+
+    expect(checkLoadedImages).toBe(true);
+
+  });
+  afterAll(async () => {
+    // Close the browser
+    await browser.close();
+  });
+});

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getThemeDocMarkdown,
   resolveImageUrls,
   countPdfItems,
+  forceImagesLoading,
 } from "../../src/generator/utils";
 
 // Mock Puppeteer
@@ -107,6 +108,24 @@ describe("Utils", () => {
 
       // Assert that absolute URLs are not modified
       expect(result).toContain('src="https://example.com/images/absolute.jpg"');
+    });
+  });
+
+  describe("forceImagesLoading", () => {
+    test("should remove loading attribute from img elements", () => {
+      const sampleHtml = `
+        <html>
+          <body>
+            <img loading='lazy' src="/images/example.jpg" />
+            <img loading='lazy' src="https://example.com/images/absolute.jpg" />
+          </body>
+        </html>
+      `;
+
+      const result = forceImagesLoading(sampleHtml);
+
+      // Assert that relative URLs are converted to absolute
+      expect(result).not.toContain('loading="lazy"');
     });
   });
 

--- a/bin/generate-pdf.ts
+++ b/bin/generate-pdf.ts
@@ -24,7 +24,8 @@ program
     "--customStyles <styles...>",
     "Custom styles to override existing CSS",
   )
-  .option("--output <path>", "Output PDF path");
+  .option("--output <path>", "Output PDF path")
+  .option("--forceImages", "Disable lazy loading for images");
 
 program.parse(process.argv);
 
@@ -51,6 +52,7 @@ async function run(options: CliFlags) {
     config.baseUrl,
     progressBar,
     config.customStyles,
+    config.forceImages
   );
 
   const mergedPdf = await mergePDFs(allPdfs);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ export function processFlags(options: CliFlags): ConfigOptions {
     customStyles: options.customStyles || configFileOptions?.customStyles || "",
     outputDir:
       options.output || configFileOptions?.outputDir || "./output/docs.pdf",
+    forceImages: options.forceImages || configFileOptions?.forceImages || false,
   };
 
   if (!config.baseUrl) {

--- a/src/generator/utils.ts
+++ b/src/generator/utils.ts
@@ -53,6 +53,22 @@ export function resolveImageUrls(html: string, baseUrl: string): string {
 }
 
 /**
+ * Disable lazy loading on images.
+ */
+
+export function forceImagesLoading(html: string): string {
+  const $ = cheerio.load(html);
+  $("img").each((_, img) => {
+    // Remove loading attribute for using the default value (eager)
+    // Loads the image immediately, regardless of whether or not the image is currently within the visible viewport.
+    $(img).removeAttr('loading');
+  })
+
+  return $.html()
+
+}
+
+/**
  * Counts PDFs for the progress bar.
  */
 export function countPdfItems(items: any[]): number {

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -16,6 +16,7 @@ export interface ProgressBar {
  * - `output`: The file path where the final PDF will be saved.
  * - `baseUrl`: The base URL of the documentation site being scraped.
  * - `entryPoint`: The starting URL for scraping the docs.
+ * - `forceImages`: If true it will disable lazy loading for images.
  */
 export type CliFlags = {
   directories: string[];
@@ -24,6 +25,7 @@ export type CliFlags = {
   entryPoint: string;
   customStyles: string;
   outputDir: string;
+  forceImages?: boolean;
 };
 
 /*
@@ -32,6 +34,7 @@ export type CliFlags = {
  * - `outputDir`: Path to the output file (same as `output`).
  * - `baseUrl`: The base URL of the site to scrape.
  * - `entryPoint`: Starting point for the scraper (could default to baseUrl + /docs/3.0).
+ * - `forceImages`: If true it will disable lazy loading for images.
  */
 export type ConfigOptions = {
   requiredDirs: string[];
@@ -39,4 +42,5 @@ export type ConfigOptions = {
   baseUrl: string;
   customStyles: string;
   entryPoint: string;
+  forceImages?: boolean;
 };


### PR DESCRIPTION
This PR introduces an option to disable lazy loading on images when generating pdf. This feature ensures that all images, including those outside the visible viewport, are fully loaded and included in the generated pdf.